### PR TITLE
Add travis-ci configuration

### DIFF
--- a/travis.yml
+++ b/travis.yml
@@ -1,0 +1,6 @@
+language: java
+
+jdk:
+  - openjdk7
+  - oraclejdk7
+  - oraclejdk8


### PR DESCRIPTION
Builds on OpenJDK 7, OracleJDK 7 and OracleJDK 8
