### PR TITLE
"ls" command now shows files more like in bash

### DIFF
--- a/src/main/java/org/jboss/aesh/extensions/ls/StringGroup.java
+++ b/src/main/java/org/jboss/aesh/extensions/ls/StringGroup.java
@@ -41,6 +41,10 @@ public class StringGroup {
         return Parser.padLeft(maxLength+1, strings[place]);
     }
 
+    public String getFormattedStringPadRight(int place) {
+        return " " + Parser.padRight(maxLength, strings[place]);
+    }
+
     public void formatStringsBasedOnMaxLength() {
         for(int i=0; i<strings.length;i++)
             strings[i] = Parser.padLeft(maxLength, strings[i]);


### PR DESCRIPTION
1. "ls"    - symbolic links are now marked with different color
2. "ls -l" - showing correct rwx attributes for symbolic links
3. "ls -l" - showing path to the target file of symbolic links
4. "ls -l" - showing time in 24h format
5. "ls -l" - showing year when file was not modified in actual year
6. "ls -l" - user and group have now padding on right as in bash
7. "ls -a" - showing "." and ".." directories
