### PR TITLE
Remove flush and close, because we are use try-with-resources statement

### DIFF
--- a/src/main/java/org/jboss/aesh/extensions/touch/Touch.java
+++ b/src/main/java/org/jboss/aesh/extensions/touch/Touch.java
@@ -53,8 +53,6 @@ public class Touch implements Command<CommandInvocation> {
                 }
                 try (OutputStream out  = file.resolve(currentWorkingDirectory).get(0).write(false)) {
                     out.write("".getBytes());
-                    out.flush();
-                    out.close();
                 }
             }
         }


### PR DESCRIPTION
Remove flush and close, because we are use try-with-resources statement, AutoClosable. :)
