### PR TITLE
Remove unused import

### DIFF
--- a/aesh/src/main/java/org/aesh/extensions/more/More.java
+++ b/aesh/src/main/java/org/aesh/extensions/more/More.java
@@ -17,7 +17,6 @@
  */
 package org.aesh.extensions.more;
 
-import javafx.scene.layout.Background;
 import org.aesh.command.Command;
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.CommandResult;


### PR DESCRIPTION
The unused import fails build on JDKs which does not contain Java FX module.